### PR TITLE
patched less-middleware and deprecated doctype 5

### DIFF
--- a/app.js
+++ b/app.js
@@ -34,7 +34,7 @@ app.use(express.methodOverride());
 app.use(express.cookieParser('your secret here'));
 app.use(express.session());
 app.use(app.router);
-app.use(require('less-middleware')({ src: path.join(__dirname, 'public') }));
+app.use(require('less-middleware')(path.join(__dirname, 'public')));
 app.use(express.static(path.join(__dirname, 'public')));
 
 // development only

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -1,4 +1,4 @@
-doctype 5
+doctype html
 html
   head
     title= title


### PR DESCRIPTION
updated to get the example to run from your example slide deck at:
http://slides.com/chriscowan/developing-node-js-with-webstorm#/

Thanks!

Signed-off-by: Brent Salisbury brent@socketplane.io
